### PR TITLE
Fix/assertEquals in clean exercises

### DIFF
--- a/01-numbers/test_numbers.py
+++ b/01-numbers/test_numbers.py
@@ -4,36 +4,36 @@ import number
 class TestArithmetics(unittest.TestCase):
     
     def test_add_two_number(self):
-        self.assertEquals(number.add(1,2), 3)
-        self.assertEquals(number.add(22,13), 35)
+        self.assertEqual(number.add(1,2), 3)
+        self.assertEqual(number.add(22,13), 35)
 
     def test_multiply(self):
         # implement number.multiply
-        self.assertEquals(number.multiply(1,2), 2)
-        self.assertEquals(number.multiply(10,2), 20)
+        self.assertEqual(number.multiply(1,2), 2)
+        self.assertEqual(number.multiply(10,2), 20)
 
     def test_safe_division(self):
         # implement number.divide, that will return 0 when you divide with 0.
-        self.assertEquals(number.divide(4,2), 2)
-        self.assertEquals(number.divide(7,3), 2)
-        self.assertEquals(number.divide(7,0), 0)
-        self.assertEquals(number.divide(0,0), 0)
-        self.assertEquals(number.divide(0,3), 0)
+        self.assertEqual(number.divide(4,2), 2)
+        self.assertEqual(number.divide(7,3), 2)
+        self.assertEqual(number.divide(7,0), 0)
+        self.assertEqual(number.divide(0,0), 0)
+        self.assertEqual(number.divide(0,3), 0)
                 
     def test_add_many(self):
         # Modify number.add to add together any number of arguments
-        self.assertEquals(number.add(1,2,3), 6)
-        self.assertEquals(number.add(1,2,3,100,1000), 1106)
+        self.assertEqual(number.add(1,2,3), 6)
+        self.assertEqual(number.add(1,2,3,100,1000), 1106)
         
     def test_multiply_should_handle_strings(self):
         # Modify number.multiply to work also if arguments are given as strings
-        self.assertEquals(number.multiply("2", "5"), 10)
-        self.assertEquals(number.multiply(4, "5"), 20)
+        self.assertEqual(number.multiply("2", "5"), 10)
+        self.assertEqual(number.multiply(4, "5"), 20)
         
     def test_add_two_largest(self):
         # Implement number.add_two_largest, that adds up together two largest numbers in its arguments
-        self.assertEquals(number.add_two_largest(6,1,2,10), 16)
-        self.assertEquals(number.add_two_largest(1,1,10,1,10), 20)
+        self.assertEqual(number.add_two_largest(6,1,2,10), 16)
+        self.assertEqual(number.add_two_largest(1,1,10,1,10), 20)
 
 if __name__ == "__main__":
     unittest.main()

--- a/02-strings/test_strings.py
+++ b/02-strings/test_strings.py
@@ -4,25 +4,25 @@ import strings
 class TestStrings(unittest.TestCase):
     
     def test_get_string_length(self):
-        self.assertEquals(strings.length(''), 0)
-        self.assertEquals(strings.length('foo'), 3)
+        self.assertEqual(strings.length(''), 0)
+        self.assertEqual(strings.length('foo'), 3)
         
     def test_get_string_without(self):
         # implement strings.without that will remove given characters
-        self.assertEquals(strings.without('abba', 'a'), 'bb')
-        self.assertEquals(strings.without('abba', 'cd'), 'abba')
-        self.assertEquals(strings.without('foobar', 'ob'), 'far')
+        self.assertEqual(strings.without('abba', 'a'), 'bb')
+        self.assertEqual(strings.without('abba', 'cd'), 'abba')
+        self.assertEqual(strings.without('foobar', 'ob'), 'far')
         
     def test_count_discint_chars(self):
         # implement strings.count_distinct that will count the number of distinct characters
-        self.assertEquals(strings.count_distinct('abba'), 2)
-        self.assertEquals(strings.count_distinct('abcdfda'), 5)
+        self.assertEqual(strings.count_distinct('abba'), 2)
+        self.assertEqual(strings.count_distinct('abcdfda'), 5)
 
     def test_tokens(self):
         # implement strings.tokens that will return a list of substrings split from . and removes empty tokens
-        self.assertEquals(strings.tokens('foo.bar'), ['foo', 'bar'])
-        self.assertEquals(strings.tokens('..foo..bar..'), ['foo', 'bar']) 
-        self.assertEquals(strings.tokens('hello'), ['hello'])
+        self.assertEqual(strings.tokens('foo.bar'), ['foo', 'bar'])
+        self.assertEqual(strings.tokens('..foo..bar..'), ['foo', 'bar'])
+        self.assertEqual(strings.tokens('hello'), ['hello'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/03-lists/test_lists.py
+++ b/03-lists/test_lists.py
@@ -3,19 +3,19 @@ import lst
 
 class TestLists(unittest.TestCase):
 
-	def test_sort_list(self):
-		self.assertEquals(lst.sort(2,1,3,7), [1,2,3,7])
-		self.assertEquals(lst.sort(2,-7), [-7,2])
-		
-	def test_find_largest_value(self):
-		# implement lst.maximum (note that is should handle also numbers that are given as strings)
-		self.assertEquals(lst.maximum(1,2,3,5,1), 5)
-		self.assertEquals(lst.maximum('11',2,'3',5,1), 11)
-		
-	def test_only_positives(self):
-		# implement lst.positives, which will return a list without negative numbers
-		self.assertEquals(lst.positives(0, -5,-1,4), [0,4])
-		self.assertEquals(lst.positives(-5,-11, -4), [])
+    def test_sort_list(self):
+        self.assertEqual(lst.sort(2,1,3,7), [1,2,3,7])
+        self.assertEqual(lst.sort(2,-7), [-7,2])
+
+    def test_find_largest_value(self):
+        # implement lst.maximum (note that is should handle also numbers that are given as strings)
+        self.assertEqual(lst.maximum(1,2,3,5,1), 5)
+        self.assertEqual(lst.maximum('11',2,'3',5,1), 11)
+
+    def test_only_positives(self):
+        # implement lst.positives, which will return a list without negative numbers
+        self.assertEqual(lst.positives(0, -5,-1,4), [0,4])
+        self.assertEqual(lst.positives(-5,-11, -4), [])
 
 if __name__ == "__main__":
     unittest.main()

--- a/04-files/test_files.py
+++ b/04-files/test_files.py
@@ -4,10 +4,10 @@ import files
 class TestFiles(unittest.TestCase):
     
     def test_read_file_contents(self):
-        self.assertEquals(files.read('test.txt'), 
+        self.assertEqual(files.read('test.txt'),
 """Beautiful is better than ugly.
 Explicit is better than implicit.""")
-        self.assertEquals(len(files.read('zen.txt')), 856)
+        self.assertEqual(len(files.read('zen.txt')), 856)
 
     def test_file_contains(self): 
         # implement files.contains that will check whether a file contains some text
@@ -18,10 +18,10 @@ Explicit is better than implicit.""")
 
     def test_return_only_rows_starting_with(self):
         # implement files.file_rows_starting_with which will return only those rows from a file that start with some string
-        self.assertEquals(files.file_rows_starting_with('Beautiful', 'test.txt'), 
+        self.assertEqual(files.file_rows_starting_with('Beautiful', 'test.txt'),
 """Beautiful is better than ugly.
 """)
-        self.assertEquals(files.file_rows_starting_with('E', 'zen.txt'), 
+        self.assertEqual(files.file_rows_starting_with('E', 'zen.txt'),
 """Explicit is better than implicit.
 Errors should never pass silently.
 """)

--- a/05-phonebook/test_phonebook.py
+++ b/05-phonebook/test_phonebook.py
@@ -18,14 +18,14 @@ class TestPhonebook(unittest.TestCase):
         self._verify_add_and_get("a", "1")
 
     def _verify_add_and_get(self, name, number):
-        self.assertEquals(phonebook.add(name, number), True)
-        self.assertEquals(phonebook.get(name), number)
+        self.assertEqual(phonebook.add(name, number), True)
+        self.assertEqual(phonebook.get(name), number)
 
     def test_get_non_existing_name(self):
         self._verify_number("Not there", "Unknown")
         
     def _verify_number(self, name, number):
-        self.assertEquals(phonebook.get(name), number)
+        self.assertEqual(phonebook.get(name), number)
 
     def test_adding_illegal_numbers(self):
         self._verify_not_added("Illegal", "not valid")
@@ -39,8 +39,8 @@ class TestPhonebook(unittest.TestCase):
         self._verify_not_added("", "123")
 
     def _verify_not_added(self, name, number):
-        self.assertEquals(phonebook.add(name, number), False)
-        self.assertEquals(phonebook.get(name), "Unknown")
+        self.assertEqual(phonebook.add(name, number), False)
+        self.assertEqual(phonebook.get(name), "Unknown")
 
     def test_clear(self):
         phonebook.add("name", "123")
@@ -48,11 +48,11 @@ class TestPhonebook(unittest.TestCase):
         self._verify_number("name", "Unknown")
         
     def test_empty_book_to_string(self):
-        self.assertEquals(phonebook._to_string(), "")
+        self.assertEqual(phonebook._to_string(), "")
         
     def test_serialize_to_string(self):
         self._add_test_names()
-        self.assertEquals(phonebook._to_string(), self.TEST_NAMES_SERIALIZED)
+        self.assertEqual(phonebook._to_string(), self.TEST_NAMES_SERIALIZED)
         
     def test_read_from_string(self):
         phonebook._read(self.TEST_NAMES_SERIALIZED)


### PR DESCRIPTION
artefact from before times, tests called `assertEquals` which is no longer a thing in Python. Change all references in `clean-exercises` to use `assertEqual`. It seems this is fixed in `main` branch.